### PR TITLE
Convert slashes on windows

### DIFF
--- a/gnuplot.nim
+++ b/gnuplot.nim
@@ -31,7 +31,10 @@ proc plotCmd(): string =
   if nplots == 0: "plot " else: "replot "
 
 proc tmpFilename(): string =
-  getTempDir() & $epochTime() & "-" & $random(1000) & ".tmp"
+  when defined(Windows):
+    (getEnv("TEMP") / ($epochTime() & "-" & $rand(1000) & ".tmp")).replace("\\", "/")
+  else:
+    getTempDir() & $epochTime() & "-" & $rand(1000) & ".tmp"
 
 proc cmd*(cmd: string) =
   echo cmd


### PR DESCRIPTION
On windows the temp filepath needs to use either a single quoted path, 'ex\ample' or forward slashes "ex/ample" so I opted for forward slashes, also using getEnv since getTempDir is discouraged and rand because random is deprecated.